### PR TITLE
Set parameters as optional. Use correct types for parameters.

### DIFF
--- a/types/forge-viewer/index.d.ts
+++ b/types/forge-viewer/index.d.ts
@@ -349,7 +349,7 @@ declare namespace Autodesk {
           searchByTag(tagsToMatch: object): BubbleNode[];
           setTag(tag: string, value: any): void;
           traverse(cb: () => void): boolean;
-          urn(searchParent: boolean): string;
+          urn(searchParent?: boolean): string;
           useAsDefault(): boolean;
         }
 
@@ -670,7 +670,7 @@ declare namespace Autodesk {
             hidePoints(hide: boolean): void;
             hideById(node: number): void;
             isolate(node: number | number[]): void;
-            isolateById(dbIds: number | number[]): void;
+            isolateById(dbIds?: number | number[]): void;
             initialize(): number | ErrorCodes;
             initSettings(): void;
             isExtensionActive(extensionID: string): boolean;
@@ -795,8 +795,8 @@ declare namespace Autodesk {
                        accessControlProperties?: object): void;
           registerViewer(viewableType: string, viewerClass: any, config?: ViewerConfig): void;
           selectItem(item: ViewerItem|BubbleNode,
-                     onSuccessCallback: (viewer: Viewer3D, item: ViewerItem) => void,
-                     onErrorCallback: (errorCode: ErrorCodes, errorMsg: string,
+                     onSuccessCallback?: (viewer: Viewer3D, item: ViewerItem) => void,
+                     onErrorCallback?: (errorCode: ErrorCodes, errorMsg: string,
                                        statusCode: string, statusText: string, messages: string) => void): boolean;
           selectItemById(itemId: number,
                          onItemSelectedCallback: (item: object, viewGeometryItem: object) => void,
@@ -999,11 +999,12 @@ declare namespace Autodesk {
             closer: HTMLElement;
             container: HTMLElement;
             content: Node;
+            scrollContainer: HTMLElement;
             title: HTMLElement;
             titleLabel: string;
 
             addEventListener(target: object, eventId: string, callback: () => void): void;
-            addVisibilityListener(callback: () => void): void;
+            addVisibilityListener(callback: (state?: boolean) => void): void;
             createCloseButton(): HTMLElement;
             createScrollContainer(options: ScrollContainerOptions): void;
             createTitleBar(title: string): HTMLElement;

--- a/types/forge-viewer/index.d.ts
+++ b/types/forge-viewer/index.d.ts
@@ -399,6 +399,15 @@ declare namespace Autodesk {
             requestThumbnailWithSecurity(data: string, onComplete: (err: Error, response: any) => void): void;
         }
 
+        class EventDispatcher {
+            constructor();
+
+            addEventListener(type: string, listener: (event: any) => void, options?: any): void;
+            removeEventListener(type: string, listener: (event: any) => void): void;
+            dispatchEvent(event: any): void;
+            hasEventListener(type: string, listener: (event: any) => void): boolean;
+        }
+
         class Extension {
             viewer: Private.GuiViewer3D;
             options: any;

--- a/types/forge-viewer/index.d.ts
+++ b/types/forge-viewer/index.d.ts
@@ -1013,7 +1013,7 @@ declare namespace Autodesk {
             titleLabel: string;
 
             addEventListener(target: object, eventId: string, callback: () => void): void;
-            addVisibilityListener(callback: (state?: boolean) => void): void;
+            addVisibilityListener(callback: (state: boolean) => void): void;
             createCloseButton(): HTMLElement;
             createScrollContainer(options: ScrollContainerOptions): void;
             createTitleBar(title: string): HTMLElement;

--- a/types/forge-viewer/index.d.ts
+++ b/types/forge-viewer/index.d.ts
@@ -642,6 +642,7 @@ declare namespace Autodesk {
             getDefaultNavigationToolName(): object;
             getDimensions(): object;
             getExplodeScale(): number;
+            getExtension(extensionId: string): Extension;
             getExtensionModes(extensionID: string): string[];
             getFirstPersonToolPopup(): boolean;
             getFocalLength(): number;

--- a/types/forge-viewer/index.d.ts
+++ b/types/forge-viewer/index.d.ts
@@ -864,9 +864,9 @@ declare namespace Autodesk {
               model: Model;
               navigation: Navigation;
 
-              addPanel(panel: UI.PropertyPanel): boolean;
+              addPanel(panel: UI.DockingPanel): boolean;
               getToolbar(create: boolean): UI.ToolBar;
-              removePanel(panel: UI.PropertyPanel): boolean;
+              removePanel(panel: UI.DockingPanel): boolean;
               resizePanels(options?: ResizePanelOptions): void;
               setLayersPanel(layersPanel: UI.LayersPanel): boolean;
               setModelStructurePanel(modelStructurePanel: UI.ModelStructurePanel): boolean;

--- a/types/forge-viewer/index.d.ts
+++ b/types/forge-viewer/index.d.ts
@@ -461,7 +461,7 @@ declare namespace Autodesk {
 
         class Model {
             fetchTopology(maxSizeMB: number): Promise<object>;
-            getBulkProperties(dbIds: number[], propFilter?: string[], successCallback?: (r: any) => void, errorCallback?: (err: any) => void): void;
+            getBulkProperties(dbIds: number[], propFilter?: string[], successCallback?: (r: PropertyResult[]) => void, errorCallback?: (err: any) => void): void;
             getData(): any;
             getFragmentList(): any;
             getObjectTree(successCallback?: (result: InstanceTree) => void, errorCallback?: (err: any) => void): void;


### PR DESCRIPTION
Some parameters & callbacks should be optional.
Use correct types for parameters (i.e. DockingPanel instead of PropertyPanel).