### PR TITLE
Update type definitions for viewer.

### DIFF
--- a/types/forge-viewer/index.d.ts
+++ b/types/forge-viewer/index.d.ts
@@ -487,7 +487,7 @@ declare namespace Autodesk {
             geomPolyCount(): number;
             getDefaultCamera(): THREE.Camera;
             getDisplayUnit(): string;
-            getDocumentNode(): object;
+            getDocumentNode(): any;
             getExternalIdMapping(onSuccessCallback: (idMapping: { [key: string]: number; }) => void, onErrorCallback: () => void): any;
             getFastLoadList(): any;
             getFragmentMap(): any;

--- a/types/forge-viewer/index.d.ts
+++ b/types/forge-viewer/index.d.ts
@@ -972,6 +972,12 @@ declare namespace Autodesk {
             class Viewer3DImpl {
                 constructor(thecanvas: any, theapi: any);
 
+                camera: THREE.Camera;
+                canvas: HTMLCanvasElement;
+                model: any;
+                scene: THREE.Scene;
+                sceneAfter: THREE.Scene;
+                selector: any;
                 visibilityManager: VisibilityManager;
 
                 addOverlay(overlayName: string, mesh: any): void;
@@ -982,10 +988,6 @@ declare namespace Autodesk {
                 initialize(needsClear: boolean, needsRender: boolean, overlayDirty: boolean): void;
                 invalidate(needsClear: boolean, needsRender?: boolean, overlayDirty?: boolean): void;
                 setLightPreset(index: number, force?: boolean): void;
-                selector: any;
-                model: any;
-                scene: THREE.Scene;
-                sceneAfter: THREE.Scene;
                 viewportToClient(viewportX: number, viewportY: number): THREE.Vector3;
                 modelqueue(): any;
                 matman(): any;
@@ -995,7 +997,6 @@ declare namespace Autodesk {
                 removeOverlay(name: string, mesh: any): any;
                 getFitBounds(p: boolean): THREE.Box3;
                 rayIntersect(ray: THREE.Ray): HitTestResult;
-
                 getRenderProxy(model: Model, fragId: number): any;
                 sceneUpdated(param: boolean): void;
                 setViewFromCamera(camera: THREE.Camera, skipTransition?: boolean, useExactCamera?: boolean): void;

--- a/types/forge-viewer/index.d.ts
+++ b/types/forge-viewer/index.d.ts
@@ -351,6 +351,13 @@ declare namespace Autodesk {
           useAsDefault(): boolean;
         }
 
+        interface Endpoint {
+            getApiEndpoint(): string;
+            getEndpointAndApi(): string;
+            setEndpointAndApi(endpoint: string, api: string): void;
+        }
+
+        let endpoint: Endpoint;
         let theExtensionManager: ExtensionManager;
 
         interface InitializerOptions {


### PR DESCRIPTION
- getDocumentNode uses any rather than object
- added interface to specify API endpoint
- Viewer3DImpl - move properties to top of the class